### PR TITLE
Use `class_name` instead of `name` for model_type

### DIFF
--- a/lib/graphql/models/definition_helpers/associations.rb
+++ b/lib/graphql/models/definition_helpers/associations.rb
@@ -38,7 +38,7 @@ module GraphQL
           graph_types = valid_types.map { |t| "#{t}Graph".safe_constantize }.compact
 
           GraphQL::UnionType.define do
-            name "#{model_type.name}#{reflection.foreign_type.classify}"
+            name "#{model_type.class_name}#{reflection.foreign_type.classify}"
             description "Objects that can be used as #{reflection.foreign_type.titleize.downcase} on #{model_type.name.titleize.downcase}"
             possible_types graph_types
           end


### PR DESCRIPTION
As name can consist `::` and it fails with GraphQL introspection query.